### PR TITLE
feature: 2fa in constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# Changelog 1.0.10 [ - December 18rd, 2024 - ]
+
+## Updated
+
+-   **[INSTANCE API]** **UPDATED TYPE** `Instance` - Added attribute `ageGate` - This will tell you if the instance has an age gate or not
+-   **[USER API]** **ADJUSTED FUNCTION** `isVRCPlusSubcriber` and `getVRCRankTags` - These functions can now be used by LimitedUser and LimitedUserFriend
+
+-   ⚠️ **Updated VRChatAPI Constructor to now include the possibility to give a 2FA Secret code to it to automatically log-in. New Attribute name is `TwoFactorAuthSecret`.** This is useful if you have 2FA enabled on your account. This will allow you to log in without having to manually enter the 2FA code every time you log in. This is a security risk, so use it with caution. This is an alternative to using the .env file to store the 2FA code. This is useful if you want to use the library in a script that runs automatically and you don't want to have to enter the 2FA code every time you run the script or if you have a user input the 2FA code every time they run the script, or similar. If you specify the 2FA Secret in the constructor, it will take over whatever you've put in the .env file.
+-   Readme updated to reflect this change.
+
 # Changelog 1.0.9 [ - December 17rd, 2024 - ]
 
 ## Fixes

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # VRC-TS - A VRChat Wrapper in TypeScript
 
-Latest version: **v1.0.9**<br>
+Latest version: **v1.0.10**<br>
 Changelogs: [CHANGELOG Link](https://github.com/lolmaxz/vrc-ts/blob/main/CHANGELOG.md)
 
 From scratch TypeScript wrapper for the VRChat API, simplifying the process of interacting with VRChat's API programmatically. Perfect if you are looking to build bots, applications, or services that interact with VRChat's API!
@@ -240,7 +240,7 @@ VRChat requires two-factor authentication (2FA). Depending on your setup (Email 
 
 3. Restart your application within **30 seconds** to complete authentication.
 
-> [!NOTE]
+> [!NOTE]  
 > **TOTP Code Validity**<br>
 > The TOTP code is valid for **30 seconds**. Ensure you use it promptly.
 
@@ -252,6 +252,14 @@ For automatic 2FA code generation:
 
     ```dotenv
     VRCHAT_2FA_SECRET=YOUR_32_CHARACTER_SECRET
+    ```
+
+    or
+
+    Add it as an optional parameter when instantiating the VRChatAPI class:
+
+    ```typescript
+    const api = new VRChatAPI({ TwoFactorAuthSecret: 'YOUR_32_CHARACTER_SECRET' });
     ```
 
 2. The application will generate TOTP codes automatically, removing the need for manual entry.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vrc-ts",
-    "version": "1.0.9",
+    "version": "1.0.10",
     "description": "A Complete VRChat Wrapper in TypeScript",
     "type": "module",
     "main": "./dist/index.cjs",
@@ -11,7 +11,7 @@
     ],
     "scripts": {
         "build": "tsup src/index.ts --format cjs,esm --dts --clean --sourcemap",
-        "test": "jest --verbose",
+        "test": "jest --verbose --silent=false",
         "dev": "ts-node src/main.ts",
         "check-exports": "attw --pack .",
         "prepare": "tsc",

--- a/src/VRChatAPI.ts
+++ b/src/VRChatAPI.ts
@@ -35,6 +35,7 @@ export type VRCApiParams = {
     userAgent?: string;
     EmailOTPCode?: string;
     TOTPCode?: string;
+    TwoFactorAuthSecret?: string;
     useCookies?: boolean;
     cookiePath?: string;
 };
@@ -58,6 +59,7 @@ export class VRChatAPI {
     currentUser: CurrentUser | null = null;
     TOTPCode: string = process.env.TOTP_2FA_CODE || '';
     EmailOTPCode: string = process.env.EMAIL_2FA_CODE || '';
+    TwoFactorAuthSecret = process.env.VRCHAT_2FA_SECRET || '';
     useCookies: boolean = process.env.USE_COOKIES === 'true' || false;
 
     authApi: AuthApi = new AuthApi(this);
@@ -79,7 +81,16 @@ export class VRChatAPI {
     userApi: UsersApi = new UsersApi(this);
     worldApi: WorldsApi = new WorldsApi(this);
 
-    constructor({ username, password, userAgent, EmailOTPCode, TOTPCode, useCookies, cookiePath }: VRCApiParams) {
+    constructor({
+        username,
+        password,
+        userAgent,
+        EmailOTPCode,
+        TOTPCode,
+        TwoFactorAuthSecret,
+        useCookies,
+        cookiePath,
+    }: VRCApiParams) {
         if (username) {
             this.username = username;
         } else {
@@ -105,6 +116,12 @@ export class VRChatAPI {
             this.TOTPCode = TOTPCode;
         } else {
             this.TOTPCode = process.env.TOTP_2FA_CODE || '';
+        }
+
+        if (TwoFactorAuthSecret) {
+            this.TwoFactorAuthSecret = TwoFactorAuthSecret;
+        } else {
+            this.TwoFactorAuthSecret = process.env.VRCHAT_2FA_SECRET || '';
         }
 
         if (useCookies) {

--- a/src/requests/UsersApi.ts
+++ b/src/requests/UsersApi.ts
@@ -251,7 +251,9 @@ export type VRCRankResult = {
  *
  * *Complete rewrite of this part, now way more optimized.*
  */
-export function getVRCRankTags(user: User.User | User.CurrentUser | User.LimitedUser): VRCRankResult {
+export function getVRCRankTags(
+    user: User.User | User.CurrentUser | User.LimitedUser | User.LimitedUserFriend
+): VRCRankResult {
     // the highest vrcrank we can find in the user's tag is the rank of the user we should return
     // Determine if the user is a troll
     const isTroll = user.tags.includes(User.VRCRanks.Nuisance) || user.tags.includes('system_probable_troll');
@@ -277,6 +279,6 @@ export function getVRCRankTags(user: User.User | User.CurrentUser | User.Limited
  * @param user The User object to check if it is a VRChat User with a current VRC+ subscription.
  * @returns `true` if the user is a VRChat User with a current VRC+ subscription, `false` otherwise.
  */
-export function isVRCPlusSubcriber(user: User.User): boolean {
+export function isVRCPlusSubcriber(user: User.User | User.LimitedUser | User.LimitedUserFriend): boolean {
     return user.tags.includes('system_supporter');
 }

--- a/src/types/Instances.ts
+++ b/src/types/Instances.ts
@@ -67,6 +67,8 @@ export type Instance = {
     hasCapacityForYou?: boolean;
     /** The time the instance was closed at. */
     closedAt?: string;
+    /** If the instance requires to be age verified or not. */
+    ageGate: boolean;
 };
 
 export type InstanceShortName = {


### PR DESCRIPTION
# Changelog 1.0.10 [ - December 18rd, 2024 - ]

## Updated

-   **[INSTANCE API]** **UPDATED TYPE** `Instance` - Added attribute `ageGate` - This will tell you if the instance has an age gate or not
-   **[USER API]** **ADJUSTED FUNCTION** `isVRCPlusSubcriber` and `getVRCRankTags` - These functions can now be used by LimitedUser and LimitedUserFriend

-   ⚠️ **Updated VRChatAPI Constructor to now include the possibility to give a 2FA Secret code to it to automatically log-in. New Attribute name is `TwoFactorAuthSecret`.** This is useful if you have 2FA enabled on your account. This will allow you to log in without having to manually enter the 2FA code every time you log in. This is a security risk, so use it with caution. This is an alternative to using the .env file to store the 2FA code. This is useful if you want to use the library in a script that runs automatically and you don't want to have to enter the 2FA code every time you run the script or if you have a user input the 2FA code every time they run the script, or similar. If you specify the 2FA Secret in the constructor, it will take over whatever you've put in the .env file.
-   Readme updated to reflect this change.