### PR TITLE
feat: roleId for filtering vrc group members

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,5 @@ jest.setup.js
 fixup.bat
 
 **./*.test.*
+tests/
+./src/tests/*.test.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Changelog 1.0.11 [ - December 21rd, 2024 - ]
+
+## Updated
+
+-   **[GROUP API]** **UPDATED REQUEST** `listGroupMembers` - Added parameter `roleId` - This will allow you to filter the members of a group by a specific role
+-   **WEBSOCKET** - Better wording for the console logs when the websocket is connected or reconnected
+
 # Changelog 1.0.10 [ - December 18rd, 2024 - ]
 
 ## Updated

--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
 # VRC-TS - A VRChat Wrapper in TypeScript
 
-Latest version: **v1.0.10**<br>
+Latest version: **v1.0.11**<br>
 Changelogs: [CHANGELOG Link](https://github.com/lolmaxz/vrc-ts/blob/main/CHANGELOG.md)
 
 From scratch TypeScript wrapper for the VRChat API, simplifying the process of interacting with VRChat's API programmatically. Perfect if you are looking to build bots, applications, or services that interact with VRChat's API!
-
-## Important notes if updating from prior to 1.0.6
 
 <details>
 <summary>⚠️ Please Read This If You Are Updating From 1.0.5 or Lower</summary>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vrc-ts",
-    "version": "1.0.10",
+    "version": "1.0.11",
     "description": "A Complete VRChat Wrapper in TypeScript",
     "type": "module",
     "main": "./dist/index.cjs",

--- a/src/requests/GroupsApi.ts
+++ b/src/requests/GroupsApi.ts
@@ -715,7 +715,7 @@ export class GroupsApi extends BaseApi {
      * Returns a List of all other Group Members. This endpoint will never return the user calling the endpoint.
      *
      * Information about the user calling the endpoint must be found in the myMember field of the Group object.
-     * @param listGroupMembersRequest - { groupId, n, offset, sort }
+     * @param listGroupMembersRequest - { groupId, n, offset, sort, roleId }
      * @returns
      */
     public async listGroupMembers({
@@ -723,6 +723,7 @@ export class GroupsApi extends BaseApi {
         n,
         offset,
         sort,
+        roleId,
     }: Group.listGroupMembersRequest): Promise<Group.GroupMember[]> {
         const parameters: URLSearchParams = new URLSearchParams();
 
@@ -731,6 +732,7 @@ export class GroupsApi extends BaseApi {
         parameters.append('n', n?.toString() || '60');
         if (offset && offset >= 0) parameters.append('offset', offset.toString());
         if (sort) parameters.append('sort', sort);
+        if (roleId) parameters.append('roleId', roleId);
 
         const paramRequest: executeRequestType = {
             currentRequest: ApiPaths.groups.listGroupMembers,

--- a/src/types/Groups.ts
+++ b/src/types/Groups.ts
@@ -926,7 +926,12 @@ export type joinGroupRequest = GroupId;
 export type leaveGroupRequest = GroupId;
 
 /** Information Required to request to get a group's members. */
-export type listGroupMembersRequest = GroupId & Quantity & Offset & groupMemberSort;
+export type listGroupMembersRequest = GroupId &
+    Quantity &
+    Offset &
+    groupMemberSort & {
+        roleId?: GroupRoleIdType;
+    };
 
 /** Information Required to request to get a group's member. */
 export type getGroupMemberRequest = GroupId & UserId;


### PR DESCRIPTION
# Changelog 1.0.11 [ - December 21rd, 2024 - ]

## Updated

-   **[GROUP API]** **UPDATED REQUEST** `listGroupMembers` - Added parameter `roleId` - This will allow you to filter the members of a group by a specific role
-   **WEBSOCKET** - Better wording for the console logs when the websocket is connected or reconnected