### PR TITLE
feat: websocket with custom URL and useragent and new impostor endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# Changelog 1.0.12 [ - December 22rd, 2024 - ]
+
+## Updated
+
+-   **WEBSOCKET** - Added a new constructor parameter `customURL` and `customUserAgent` - This will allow you to specify a custom URL and User-Agent for the websocket connection. The custom URL will override the default URL for the websocket connection. The custom User-Agent will override the default User-Agent for the websocket connection.
+
+-   **[AVATAR API]** **ADDED NEW ENDPOINT** `generateImpostor` - This will allow you to generate an impostor for a specific avatar, requires an avatarId
+-   **[AVATAR API]** **ADDED NEW ENDPOINT** `deleteImpostor` - This will allow you to delete an impostor for a specific avatar, requires an avatarId
+
 # Changelog 1.0.11 [ - December 21rd, 2024 - ]
 
 ## Updated

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # VRC-TS - A VRChat Wrapper in TypeScript
 
-Latest version: **v1.0.11**<br>
+Latest version: **v1.0.12**<br>
 Changelogs: [CHANGELOG Link](https://github.com/lolmaxz/vrc-ts/blob/main/CHANGELOG.md)
 
 From scratch TypeScript wrapper for the VRChat API, simplifying the process of interacting with VRChat's API programmatically. Perfect if you are looking to build bots, applications, or services that interact with VRChat's API!
@@ -297,7 +297,7 @@ Here is the full list of endpoints by category that this wrapper implements. For
 
 **Avatars API**:
 
--   `getOwnAvatar`, `searchAvatars`, `createAvatar`, `getAvatar`, `updateAvatar`, `deleteAvatar`, `selectAvatar`, `selectFallbackAvatar`, `listFavoritedAvatars`, `getImpostorQueueStats`
+-   `getOwnAvatar`, `searchAvatars`, `createAvatar`, `getAvatar`, `updateAvatar`, `deleteAvatar`, `selectAvatar`, `selectFallbackAvatar`, `listFavoritedAvatars`, `getImpostorQueueStats`, `generateImpostor`, `deleteImpostor`
 
 **Beta API**:
 
@@ -391,7 +391,6 @@ const api = new VRChatAPI({});
 const ws = new VRCWebSocket({
     vrchatAPI: api,
     eventsToListenTo: [EventType.All],
-    logAllEvents: false,
 });
 
 // Listening to friend online events
@@ -410,7 +409,6 @@ const api = new VRChatAPI({});
 const ws = new VRCWebSocket({
     vrchatAPI: api,
     eventsToListenTo: [EventType.All],
-    logAllEvents: false,
 });
 
 // Listening to friend online events
@@ -424,7 +422,7 @@ ws.on(EventType.Friend_Online, (data) => {
 
 ### Specifying Events to Listen To
 
-You can specify which events you want to listen to:
+You can specify which events you want to listen to (Default: `EventType.All`):
 
 ```typescript
 import { VRChatAPI, VRCWebSocket, EventType, friendRequestNotification } from 'vrc-ts';
@@ -448,6 +446,25 @@ ws.on(EventType.Friend_Request, (eventData: friendRequestNotification) => {
 > [!TIP]
 > Description of each events can be found [here](<https://github.com/lolmaxz/vrc-ts/wiki/VRC-WebSocket-API-(Draft-WIP)#3-event-types>).
 
+All Events logs is turned off by default. You can enable it by setting the `logAllEvents` parameter to `true` when initializing the WebSocket in the constructor.
+
+You can also start the websocket using a custom URL by setting the `customURL` parameter to the URL you want to use, as well as the User-Agent for the WebSocket, with the `customUserAgent` parameter.
+
+Here is an example of how to do it:
+```typescript
+import { VRChatAPI, VRCWebSocket } from 'vrc-ts';
+
+const api = new VRChatAPI({});
+
+const ws = new VRCWebSocket({
+    customURL: 'wss://customurl.com',
+    customUserAgent: 'CustomUserAgent/0.0.1'
+});
+```
+
+> [!IMPORTANT]
+> **WebSocket Connection**<br>
+> If you do not specify the VRChatAPI instance, you **NEED** to specify the `customUserAgent` parameter in the WebSocket constructor.
 ---
 
 ## Basic Example

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vrc-ts",
-    "version": "1.0.11",
+    "version": "1.0.12",
     "description": "A Complete VRChat Wrapper in TypeScript",
     "type": "module",
     "main": "./dist/index.cjs",

--- a/src/requests/AvatarsApi.ts
+++ b/src/requests/AvatarsApi.ts
@@ -261,4 +261,22 @@ export class AvatarsApi extends BaseApi {
 
         return await this.executeRequest<Avi.Avatar[]>(paramRequest);
     }
+
+    public async generateImpostor({ avatarId }: Avi.dataKeysCreateImpostor): Promise<Avi.ImpostorCreation> {
+        const paramRequest: executeRequestType = {
+            currentRequest: ApiPaths.avatars.generateImpostor,
+            pathFormated: ApiPaths.avatars.generateImpostor.path.replace('{avatarId}', avatarId),
+        };
+
+        return await this.executeRequest<Avi.ImpostorCreation>(paramRequest);
+    }
+
+    public async deleteImpostor({ avatarId }: Avi.dataKeysDeleteImpostor): Promise<Avi.ImpostorDeletion> {
+        const paramRequest: executeRequestType = {
+            currentRequest: ApiPaths.avatars.generateImpostor,
+            pathFormated: ApiPaths.avatars.generateImpostor.path.replace('{avatarId}', avatarId),
+        };
+
+        return await this.executeRequest<Avi.ImpostorDeletion>(paramRequest);
+    }
 }

--- a/src/types/ApiPaths.ts
+++ b/src/types/ApiPaths.ts
@@ -24,6 +24,8 @@ export const ApiPaths: APIPaths = {
         selectFallbackAvatar: { path: "/avatars/{avatarId}/selectFallback", method: "PUT", cookiesNeeded: ["authCookie"] },
         listFavoritedAvatars: { path: "/avatars/favorites", method: "GET", cookiesNeeded: ["authCookie"] },
         getImpostorQueueStats: { path: "/avatars/impostor/queue/stats", method: "GET", cookiesNeeded: ["authCookie"], notImplemented: true },
+        generateImpostor: { path: "/avatars/{avatarId}/impostor/enqueue", method: "POST", cookiesNeeded: ["authCookie"], requiredQueryParams: ["avatarId"] },
+        deleteImpostor: { path: "/avatars/{avatarId}/impostor", method: "DELETE", cookiesNeeded: ["authCookie"], requiredQueryParams: ["avatarId"] },
     },
     beta: {
         getIOSClosedBetaInformation: { path: "/beta/ios-closed-beta", method: "GET", cookiesNeeded: ["authCookie"] },

--- a/src/types/Avatars.ts
+++ b/src/types/Avatars.ts
@@ -1,5 +1,5 @@
 import { UnityPackageAvatar } from './Files';
-import { AllTags, AvatarIdType, SearchOrderOptions, SearchSortingOptions, UserIdType } from './Generics';
+import { AllTags, AvatarIdType, BaseId, SearchOrderOptions, SearchSortingOptions, UserIdType } from './Generics';
 
 //! --- Avatars --- !//
 
@@ -56,6 +56,28 @@ export enum AvatarReleaseStatus {
     Hidden = 'hidden',
     All = 'all',
 }
+
+/**
+ * Impostor Creation Status
+ **/
+export type ImpostorCreation = {
+    created_at: string;
+    id: BaseId;
+    progress: unknown[];
+    requesterUserId: string;
+    state: string; // Always seems to be "QUEUED"
+    subjectId: AvatarIdType;
+    subjectType: string; // Always seems to be "avatar"
+    type: 'IMPOSTORIZE'; // Always seems to be "IMPOSTORIZE"
+    updated_at: string;
+};
+
+/**
+ * Impostor Deletion Status
+ **/
+export type ImpostorDeletion = {
+    removed: number;
+};
 
 //! --- Requests --- !//
 
@@ -204,4 +226,12 @@ export type listFavoritedAvatarsOption = {
     platform?: string;
     /** The UserId of the user who uploaded the avatar */
     userId?: UserIdType;
+};
+
+export type dataKeysCreateImpostor = {
+    avatarId: AvatarIdType;
+};
+
+export type dataKeysDeleteImpostor = {
+    avatarId: AvatarIdType;
 };

--- a/src/types/Generics.ts
+++ b/src/types/Generics.ts
@@ -1,4 +1,4 @@
-import { createAvatarOption, updateAvatarOption } from './Avatars';
+import { createAvatarOption, dataKeysCreateImpostor, dataKeysDeleteImpostor, updateAvatarOption } from './Avatars';
 import {
     GetLicenseGroupRequest,
     GetLicenseRequest,
@@ -198,6 +198,8 @@ export type APIPaths = {
         selectFallbackAvatar: subSectionType;
         listFavoritedAvatars: subSectionType;
         getImpostorQueueStats: subSectionType;
+        generateImpostor: subSectionType;
+        deleteImpostor: subSectionType;
     };
     beta: {
         getIOSClosedBetaInformation: subSectionType;
@@ -432,7 +434,9 @@ export type dataSetKeys =
     | dataKeysCreateGroupInstance
     | dataKeysGetUserSubmittedFeedback
     | dataKeysUpdateUserNote
-    | dataKeysRespondToNotificationRequest;
+    | dataKeysRespondToNotificationRequest
+    | dataKeysCreateImpostor
+    | dataKeysDeleteImpostor;
 
 export type dataKeys2Fa = {
     code: string;


### PR DESCRIPTION
# Changelog 1.0.12 [ - December 22rd, 2024 - ]

## Updated

-   **WEBSOCKET** - Added a new constructor parameter `customURL` and `customUserAgent` - This will allow you to specify a custom URL and User-Agent for the websocket connection. The custom URL will override the default URL for the websocket connection. The custom User-Agent will override the default User-Agent for the websocket connection.

-   **[AVATAR API]** **ADDED NEW ENDPOINT** `generateImpostor` - This will allow you to generate an impostor for a specific avatar, requires an avatarId
-   **[AVATAR API]** **ADDED NEW ENDPOINT** `deleteImpostor` - This will allow you to delete an impostor for a specific avatar, requires an avatarId
