### PR TITLE
feat: new avatar endpoint getImpostorQueueStats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Changelog 1.0.13 [ - December 22rd, 2024 - ]
+
+## Updated
+
+-   **[AVATAR API]** **ADDED NEW ENDPOINT** `getImpostorQueueStats` - This will allow you to get the state of the impostor queue and know how long it will take to generate an impostor at the current moment.
+
 # Changelog 1.0.12 [ - December 22rd, 2024 - ]
 
 ## Updated

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # VRC-TS - A VRChat Wrapper in TypeScript
 
-Latest version: **v1.0.12**<br>
+Latest version: **v1.0.13**<br>
 Changelogs: [CHANGELOG Link](https://github.com/lolmaxz/vrc-ts/blob/main/CHANGELOG.md)
 
 From scratch TypeScript wrapper for the VRChat API, simplifying the process of interacting with VRChat's API programmatically. Perfect if you are looking to build bots, applications, or services that interact with VRChat's API!

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vrc-ts",
-    "version": "1.0.12",
+    "version": "1.0.13",
     "description": "A Complete VRChat Wrapper in TypeScript",
     "type": "module",
     "main": "./dist/index.cjs",

--- a/src/requests/AvatarsApi.ts
+++ b/src/requests/AvatarsApi.ts
@@ -262,6 +262,21 @@ export class AvatarsApi extends BaseApi {
         return await this.executeRequest<Avi.Avatar[]>(paramRequest);
     }
 
+    /**
+     * Get the current average queue time for the impostor generation queue.
+     **/
+    public async getImpostorQueueStats(): Promise<Avi.ImpostorQueue> {
+        const paramRequest: executeRequestType = {
+            currentRequest: ApiPaths.avatars.getImpostorQueueStats,
+            pathFormated: ApiPaths.avatars.getImpostorQueueStats.path,
+        };
+
+        return await this.executeRequest<Avi.ImpostorQueue>(paramRequest);
+    }
+
+    /**
+     * Generate an impostor for the avatar.
+     */
     public async generateImpostor({ avatarId }: Avi.dataKeysCreateImpostor): Promise<Avi.ImpostorCreation> {
         const paramRequest: executeRequestType = {
             currentRequest: ApiPaths.avatars.generateImpostor,
@@ -271,6 +286,9 @@ export class AvatarsApi extends BaseApi {
         return await this.executeRequest<Avi.ImpostorCreation>(paramRequest);
     }
 
+    /**
+     * Delete the impostor for the avatar.
+     */
     public async deleteImpostor({ avatarId }: Avi.dataKeysDeleteImpostor): Promise<Avi.ImpostorDeletion> {
         const paramRequest: executeRequestType = {
             currentRequest: ApiPaths.avatars.generateImpostor,

--- a/src/types/ApiPaths.ts
+++ b/src/types/ApiPaths.ts
@@ -23,7 +23,7 @@ export const ApiPaths: APIPaths = {
         selectAvatar: { path: "/avatars/{avatarId}/select", method: "PUT", cookiesNeeded: ["authCookie"] },
         selectFallbackAvatar: { path: "/avatars/{avatarId}/selectFallback", method: "PUT", cookiesNeeded: ["authCookie"] },
         listFavoritedAvatars: { path: "/avatars/favorites", method: "GET", cookiesNeeded: ["authCookie"] },
-        getImpostorQueueStats: { path: "/avatars/impostor/queue/stats", method: "GET", cookiesNeeded: ["authCookie"], notImplemented: true },
+        getImpostorQueueStats: { path: "/avatars/impostor/queue/stats", method: "GET", cookiesNeeded: ["authCookie"] },
         generateImpostor: { path: "/avatars/{avatarId}/impostor/enqueue", method: "POST", cookiesNeeded: ["authCookie"], requiredQueryParams: ["avatarId"] },
         deleteImpostor: { path: "/avatars/{avatarId}/impostor", method: "DELETE", cookiesNeeded: ["authCookie"], requiredQueryParams: ["avatarId"] },
     },

--- a/src/types/Avatars.ts
+++ b/src/types/Avatars.ts
@@ -59,6 +59,15 @@ export enum AvatarReleaseStatus {
 
 /**
  * Impostor Creation Status
+ *
+ * Tells you how long it will take to create the impostor avatar.
+ **/
+export type ImpostorQueue = {
+    estimatedServiceDurationSeconds: number;
+};
+
+/**
+ * Impostor Creation Status
  **/
 export type ImpostorCreation = {
     created_at: string;


### PR DESCRIPTION
# Changelog 1.0.13 [ - December 22rd, 2024 - ]

## Updated

-   **[AVATAR API]** **ADDED NEW ENDPOINT** `getImpostorQueueStats` - This will allow you to get the state of the impostor queue and know how long it will take to generate an impostor at the current moment.