### PR TITLE
add missing group announcement property

### DIFF
--- a/src/requests/VRCWebSocketApi.ts
+++ b/src/requests/VRCWebSocketApi.ts
@@ -918,6 +918,7 @@ export type NotificationV2GroupInformative = BaseNotificationV2 & {
 export type NotificationV2GroupAnnouncement = BaseNotificationV2 & {
     data: {
         groupName: string;
+        groupId: string;
         announcementTitle: string;
     };
 };


### PR DESCRIPTION
this property is missing the id field
![image](https://github.com/user-attachments/assets/9396bc77-b86d-4c31-a34c-d9d562d27e38)
