### PR TITLE
chore: bump version to 1.0.15 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vrc-ts",
-    "version": "1.0.14",
+    "version": "1.0.15",
     "description": "A Complete VRChat Wrapper in TypeScript",
     "type": "module",
     "main": "./dist/index.cjs",


### PR DESCRIPTION
This pull request includes a version update for the `vrc-ts` package.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version from `1.0.14` to `1.0.15`.